### PR TITLE
Step3: 사다리(게임 실행)

### DIFF
--- a/src/main/java/ladder/LadderGame.java
+++ b/src/main/java/ladder/LadderGame.java
@@ -5,15 +5,27 @@ import ladder.domain.RandomLinkStrategy;
 import ladder.ui.InputView;
 import ladder.ui.OutputView;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 
 public class LadderGame {
     public static void main(String[] args) {
         List<String> attendees = InputView.getAttendees();
+        List<String> prizes = InputView.getPrizes();
         int height = InputView.getHeight();
 
         Ladder ladder = Ladder.of(attendees.size(), height, new RandomLinkStrategy());
-        OutputView.showAttendees(attendees);
-        OutputView.showLadder(ladder);
+        OutputView.showLadder(attendees, ladder, prizes);
+
+        List<Integer> result = ladder.getResult();
+        Map<String, String> prizeTable = IntStream.range(0, attendees.size())
+                .collect(HashMap::new, (m, i) -> m.put(attendees.get(i), prizes.get(result.get(i))), HashMap::putAll);
+
+        String who;
+        while(!(who = InputView.whoseResult()).isEmpty()) {
+            OutputView.showPrize(prizeTable, who);
+        }
     }
 }

--- a/src/main/java/ladder/domain/Ladder.java
+++ b/src/main/java/ladder/domain/Ladder.java
@@ -26,4 +26,12 @@ public class Ladder {
     public List<Row> getRows() {
         return Collections.unmodifiableList(rows);
     }
+
+    public List<Integer> getResult() {
+        final List<Integer> initialPosition = IntStream.rangeClosed(0, rows.get(0).getLinks().size())
+                .boxed()
+                .collect(Collectors.toList());
+        return rows.stream()
+                .reduce(initialPosition, (pos, row) -> row.step(pos), (pos1, pos2) -> pos2);
+    }
 }

--- a/src/main/java/ladder/domain/Ladder.java
+++ b/src/main/java/ladder/domain/Ladder.java
@@ -1,9 +1,9 @@
 package ladder.domain;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 public class Ladder {
     private static final int MINIMUM_HEIGHT = 1;
@@ -23,7 +23,7 @@ public class Ladder {
         );
     }
 
-    public Stream<Row> stream() {
-        return rows.stream();
+    public List<Row> getRows() {
+        return Collections.unmodifiableList(rows);
     }
 }

--- a/src/main/java/ladder/domain/RandomLinkStrategy.java
+++ b/src/main/java/ladder/domain/RandomLinkStrategy.java
@@ -3,11 +3,10 @@ package ladder.domain;
 import java.util.Random;
 
 public class RandomLinkStrategy implements LinkStrategy {
-    private static final int THRESHOLD = 4;
     private final Random random = new Random();
 
     @Override
     public boolean tryLink() {
-        return random.nextInt(THRESHOLD * 2) >= THRESHOLD;
+        return random.nextBoolean();
     }
 }

--- a/src/main/java/ladder/domain/Row.java
+++ b/src/main/java/ladder/domain/Row.java
@@ -27,4 +27,20 @@ public class Row {
     public List<Boolean> getLinks() {
         return Collections.unmodifiableList(links);
     }
+
+    public List<Integer> step(List<Integer> positions) {
+        return positions.stream()
+                .map(this::getNextColumn)
+                .collect(Collectors.toList());
+    }
+
+    private int getNextColumn(int fromColumn) {
+        if (fromColumn > 0 && links.get(fromColumn - 1)) {
+            return fromColumn - 1;
+        }
+        if (fromColumn < links.size() && links.get(fromColumn)) {
+            return fromColumn + 1;
+        }
+        return fromColumn;
+    }
 }

--- a/src/main/java/ladder/ui/InputView.java
+++ b/src/main/java/ladder/ui/InputView.java
@@ -13,8 +13,18 @@ public class InputView {
         return Arrays.asList(scanner.nextLine().split(DELIMITER));
     }
 
+    public static List<String> getPrizes() {
+        System.out.println("실행 결과를 입력하세요. (결과는 쉼표(,)로 구분하세요)");
+        return Arrays.asList(scanner.nextLine().split(DELIMITER));
+    }
+
     public static int getHeight() {
         System.out.println("최대 사다리 높이는 몇 개인가요?");
         return Integer.parseInt(scanner.nextLine());
+    }
+
+    public static String whoseResult() {
+        System.out.println("결과를 보고 싶은 사람은?");
+        return scanner.nextLine();
     }
 }

--- a/src/main/java/ladder/ui/OutputView.java
+++ b/src/main/java/ladder/ui/OutputView.java
@@ -26,7 +26,7 @@ public class OutputView {
     }
 
     public static void showLadder(Ladder ladder) {
-        ladder.stream()
+        ladder.getRows().stream()
                 .map(OutputView::rowToString)
                 .forEach(System.out::println);
     }

--- a/src/main/java/ladder/ui/OutputView.java
+++ b/src/main/java/ladder/ui/OutputView.java
@@ -4,29 +4,40 @@ import ladder.domain.Ladder;
 import ladder.domain.Row;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class OutputView {
     private static final String COLUMN_MARKER = "|";
     private static final String LINK_MARKER = "-----";
     private static final String SPACE       = "     ";
+    private static final String PRIZE_ALL = "all";
 
-    public static void showAttendees(List<String> attendees) {
-        String outputLine = attendees.stream()
+    public static void showLadder(List<String> attendees, Ladder ladder, List<String> prizes) {
+        showLabels(attendees);
+        showRows(ladder.getRows());
+        showLabels(prizes);
+    }
+
+    private static void showLabels(List<String> labels) {
+        String outputLine = labels.stream()
                 .map(OutputView::centered)
                 .collect(Collectors.joining(" "));
         System.out.println(outputLine);
     }
 
     private static String centered(String text) {
-        int margin = SPACE.length() - text.length();
+        int length = text.codePoints()
+                .map(c -> c < 128 ? 1 : 2)
+                .reduce(0, Integer::sum);
+        int margin = SPACE.length() - length;
         return SPACE.substring(0, margin / 2) +
                 text +
                 SPACE.substring(0, (margin + 1) / 2);
     }
 
-    public static void showLadder(Ladder ladder) {
-        ladder.getRows().stream()
+    private static void showRows(List<Row> rows) {
+        rows.stream()
                 .map(OutputView::rowToString)
                 .forEach(System.out::println);
     }
@@ -37,5 +48,19 @@ public class OutputView {
                 .map(link -> link ? LINK_MARKER : SPACE)
                 .forEach(marker -> sb.append(marker).append(COLUMN_MARKER));
         return sb.toString();
+    }
+
+    public static void showPrize(Map<String, String> prizeTable, String whosePrize) {
+        System.out.println("실행 결과");
+
+        if (!PRIZE_ALL.equals(whosePrize)) {
+            System.out.println(prizeTable.get(whosePrize));
+            return;
+        }
+
+        prizeTable.forEach((who, prize) -> {
+            System.out.format("%s: ", who);
+            System.out.println(prize);
+        });
     }
 }

--- a/src/test/java/ladder/domain/LadderTest.java
+++ b/src/test/java/ladder/domain/LadderTest.java
@@ -3,6 +3,10 @@ package ladder.domain;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -43,5 +47,22 @@ public class LadderTest {
                 .flatMap(r -> r.getLinks().stream())
                 .filter(b -> b)
                 .count()).isEqualTo(0);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "3, 1, 1|0|2",
+            "3, 2, 0|1|2",
+            "3, 3, 1|0|2",
+            "4, 4, 0|1|2|3",
+            "4, 5, 1|0|3|2",
+    })
+    void testResult(int width, int height, String expected) {
+        List<Integer> then = Arrays.stream(expected.split("\\|"))
+                .map(Integer::parseInt)
+                .collect(Collectors.toList());
+
+        assertThat(Ladder.of(width, height, () -> true).getResult())
+                .isEqualTo(then);
     }
 }

--- a/src/test/java/ladder/domain/LadderTest.java
+++ b/src/test/java/ladder/domain/LadderTest.java
@@ -1,10 +1,7 @@
 package ladder.domain;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -37,12 +34,12 @@ public class LadderTest {
     })
     void testLinkCount(int width, int height) {
         int expected = width / 2 * height;
-        assertThat(Ladder.of(width, height, () -> true).stream()
+        assertThat(Ladder.of(width, height, () -> true).getRows().stream()
                 .flatMap(r -> r.getLinks().stream())
                 .filter(b -> b)
                 .count()).isEqualTo(expected);
 
-        assertThat(Ladder.of(width, height, () -> false).stream()
+        assertThat(Ladder.of(width, height, () -> false).getRows().stream()
                 .flatMap(r -> r.getLinks().stream())
                 .filter(b -> b)
                 .count()).isEqualTo(0);

--- a/src/test/java/ladder/domain/RowTest.java
+++ b/src/test/java/ladder/domain/RowTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,5 +55,35 @@ public class RowTest {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> Row.of(numberPerson, () -> false));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1, 0",
+            "2, 1|0",
+            "3, 1|0|2",
+            "4, 1|0|3|2",
+            "5, 1|0|3|2|4",
+            "6, 1|0|3|2|5|4"
+    })
+    void testStepForAlways(int numberPerson, String expected) {
+        List<Integer> when = IntStream.range(0, numberPerson)
+                .boxed()
+                .collect(Collectors.toList());
+        List<Integer> then = Arrays.stream(expected.split("\\|"))
+                .map(Integer::parseInt)
+                .collect(Collectors.toList());
+        Row row = Row.of(numberPerson, () -> true);
+        assertThat(row.step(when)).isEqualTo(then);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 4, 5, 6 })
+    void testStepForNever(int numberPerson) {
+        List<Integer> when = IntStream.range(0, numberPerson)
+                .boxed()
+                .collect(Collectors.toList());
+        Row row = Row.of(numberPerson, () -> false);
+        assertThat(row.step(when)).isEqualTo(when);
     }
 }


### PR DESCRIPTION
사다리 게임을 실행하는 기능 추가입니다

### `Row`: 사다리 한 행
- `step`: 전체 column에 대해 행을 한차례 진행하고, 다음 column들의 index를 반환합니다

### `Ladder`: 사다리
- `getResult`: 사다리를 모두 진행한 결과 column index를 반환합니다.
   - `Row.step`을 적극 이용합니다

### `LadderGame`: 사다리 게임
- 사다리 결과 index를 가져와서, 게임 결과(상금)을 각 index에 대로 정렬한 후 참여자와 매핑합니다.
- 매핑한 참여자 정보는 결과 출력이 에용합니다.